### PR TITLE
Remove pluralisation of "cow" to "kine"

### DIFF
--- a/src/Inflect/Inflect.php
+++ b/src/Inflect/Inflect.php
@@ -69,7 +69,6 @@ class Inflect
     static $irregular = array(
         'zombie' => 'zombies',
         'move'   => 'moves',
-        'cow'    => 'kine',
         'foot'   => 'feet',
         'goose'  => 'geese',
         'sex'    => 'sexes',

--- a/tests/InflectTest.php
+++ b/tests/InflectTest.php
@@ -37,6 +37,7 @@ class InflectTest extends PHPUnit_Framework_TestCase
                 'toes' => 'toe',
                 'banjoes' => 'banjo',
                 'vetoes' => 'veto',
+                'cows' => 'cow',
             );
 
         foreach ($inflections as $key => $value)
@@ -77,6 +78,7 @@ class InflectTest extends PHPUnit_Framework_TestCase
                 'toes' => 'toe',
                 'banjos' => 'banjo',
                 'vetoes' => 'veto',
+                'cows' => 'cow',
                 );
         foreach ($inflections as $key => $value)
         {


### PR DESCRIPTION
As much as I love the work "Kine" - I think "Cows" is a better pluralisation of "Cow"

http://dictionary.reference.com/browse/kine